### PR TITLE
Fix hex viewer digit width calculation

### DIFF
--- a/src/viewer/HexViewer.js
+++ b/src/viewer/HexViewer.js
@@ -6,7 +6,7 @@ export default class HexViewer extends React.Component {
   render() {
     const { data, className, ...props } = this.props;
     let numDigits = 4;
-    while (1 << (numDigits * 4) <= data.length) {
+    while (Math.pow(16, numDigits) <= data.length) {
       numDigits += 1;
     }
     const lineNumbers = [], hexView = [], asciiView = [];


### PR DESCRIPTION
## Summary
- improve line number width calculation in HexViewer

## Testing
- `npm run build` *(fails: Cannot find module 'webpack')*

------
https://chatgpt.com/codex/tasks/task_e_68409a7eb004832d8b4bab11d8e9d68c